### PR TITLE
nifi.properties safety valve

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 name: nifi
-version: 0.2.2
+version: 0.2.3
 appVersion: 1.9.2
 description: Apache NiFi is a software project from the Apache Software Foundation designed to automate the flow of data between software systems. 
 keywords:

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The following table lists the configurable parameters of the nifi chart and the 
 | `properties.siteToSite.secure`                                              | Site to Site properties Secure mode                                                                                | `false`                         |
 | `properties.siteToSite.port`                                                | Site to Site properties Secure port                                                                                | `10000`                         |
 | `properties.siteToSite.authorizer`                                          |                                                                                                                    | `managed-authorizer`            |
+| `properties.safetyValve`                                                    | Map of explicit 'property: value' pairs that overwrite other configuration                                         | `nil`                           |
 | **nifi user authentication**                                                |
 | `auth.ldap.enabled`                                                         | Enable User auth via ldap                                                                                          | `false`                         |
 | `auth.ldap.host`                                                            | ldap hostname                                                                                                      | `ldap://<hostname>:<port>`      |

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -88,9 +88,13 @@ spec:
         - -ce
         - |
           prop_replace () {
-            target_file=${NIFI_HOME}/conf/nifi.properties
-            echo 'replacing target file ' ${target_file}
-            sed -i -e "s|^$1=.*$|$1=$2|"  ${target_file}
+            target_file=${NIFI_HOME}/conf/${3:-nifi.properties}
+            echo "updating ${1} in ${target_file}"
+            if egrep "^${1}=" ${target_file} &> /dev/null; then
+              sed -i -e "s|^$1=.*$|$1=$2|"  ${target_file}
+            else
+              echo ${1}=${2} >> ${target_file}
+            fi
           }
 
           FQDN=$(hostname -f)
@@ -107,6 +111,12 @@ spec:
           prop_replace nifi.cluster.node.address ${FQDN}
           prop_replace nifi.web.http.host ${FQDN}
           prop_replace nifi.zookeeper.connect.string ${NIFI_ZOOKEEPER_CONNECT_STRING}
+
+{{- if .Values.properties.safetyValve }}
+  {{- range $prop, $val := .Values.properties.safetyValve }}
+          prop_replace {{ $prop }} "{{ $val }}" nifi.properties
+  {{- end }}
+{{- end }}
 
           exec bin/nifi.sh run
         resources:

--- a/values.yaml
+++ b/values.yaml
@@ -49,8 +49,8 @@ properties:
     secure: false
     port: 10000
   authorizer: managed-authorizer
-  # properties.safetyValve Explicit 'key: value' pairs that overwrite other configuration
-  safetyValve:
+  # use properties.safetyValve to pass explicit 'key: value' pairs that overwrite other configuration
+  # safetyValve:
     #nifi.variable.registry.properties: "${NIFI_HOME}/example1.properties, ${NIFI_HOME}/example2.properties"
 
 ## Include additional libraries in the Nifi containers by using the postStart handler

--- a/values.yaml
+++ b/values.yaml
@@ -49,6 +49,9 @@ properties:
     secure: false
     port: 10000
   authorizer: managed-authorizer
+  # properties.safetyValve Explicit 'key: value' pairs that overwrite other configuration
+  safetyValve:
+    #nifi.variable.registry.properties: "${NIFI_HOME}/example1.properties, ${NIFI_HOME}/example2.properties"
 
 ## Include additional libraries in the Nifi containers by using the postStart handler
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/


### PR DESCRIPTION
Configure any nifi.properties line from values.yaml

#### What this PR does / why we need it:
Provides flexibility to set properties not already handled by this chart.  This can include using environment variables in values.yaml to accommodate nifi docker environment variables.

_Example_
```
properties:
  safetyValve:
    nifi.variable.registry.properties: ${NIFI_VARIABLE_REGISTRY_PROPERTIES}
    some.new.property: "some new value"
```

#### Which issue this PR fixes
  - fixes #15

#### Special notes for your reviewer:
I didn't see a `./ci` directory to put test-values.yaml files.  Should I create them?

`prop_replace` method now takes a third argument for file name. I started to add the ability to change bootstrap.conf in a similar fashion as nifi.properties before realizing that the nifi user doesn't have permissions to write so it.  This can be explored later if needed.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
