### PR TITLE
add initContainers, extraVolumes and extraVolumeMounts to values

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 name: nifi
-version: 0.3.3
+version: 0.3.4
 appVersion: 1.11.0
 description: Apache NiFi is a software project from the Apache Software Foundation designed to automate the flow of data between software systems.
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 name: nifi
-version: 0.3.2
+version: 0.3.3
 appVersion: 1.11.0
 description: Apache NiFi is a software project from the Apache Software Foundation designed to automate the flow of data between software systems.
 keywords:

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ The following table lists the configurable parameters of the nifi chart and the 
 | `nodeSelector`                                                              | Node labels for pod assignment                                                                                     | `{}`                            |
 | **tolerations**                                                             |
 | `tolerations`                                                               | Tolerations for pod assignment                                                                                     | `[]`                            |
+| **initContainers**                                                          |
+| `initContainers`                                                            | Container definition that will be added to the pod as [initContainers](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#container-v1-core) | `[]`                            |
+| **extraVolumes**                                                            |
+| `extraVolumes`                                                              | Additional Volumes available within the pod (see [spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#volume-v1-core) for format)       | `[]`                            |
+| **extraVolumeMounts**                                                       |
+| `extraVolumeMounts`                                                         | VolumeMounts for the nifi-server container (see [spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#volumemount-v1-core) for details)  | `[]`                            |
 | **zookeeper**                                                               |
 |`zookeeper.enabled`                                                          | If true, deploy Zookeeper                                                                                          | `true`                          |
 |`zookeeper.url`                                                              | If the Zookeeper Chart is disabled a URL and port are required to connect                                          | `nil`                           |

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ The following table lists the configurable parameters of the nifi chart and the 
 | `sts.AntiAffinity`                                                          | Affinity for pod assignment                                                                                        | `soft`                          |
 | **secrets**
 | `secrets`                                                                   | Pass any secrets to the nifi pods. The secret can also be mounted to a specific path if required.                  | `nil`                           |
+| **configmaps**
+| `configmaps`                                                                | Pass any configmaps to the nifi pods. The configmap can also be mounted to a specific path if required.            | `nil`                           |
 | **nifi properties**                                                         |
 | `properties.externalSecure`                                                 | externalSecure for when inbound SSL                                                                                | `false`                         |
 | `properties.isNode`                                                         | cluster node properties (only configure for cluster nodes)                                                         | `true`                          |

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -241,6 +241,22 @@ spec:
               {{- end }}
             {{- end }}
           {{- end }}
+          {{- range $configmap := .Values.configmaps }}
+            {{- if $configmap.mountPath }}
+              {{- if $configmap.keys }}
+                {{- range $key := $configmap.keys }}
+          - name: {{ include "apache-nifi.fullname" $ }}-{{ $configmap.name }}
+            mountPath: {{ $configmap.mountPath }}/{{ $key }}
+            subPath: {{ $key }}
+            readOnly: true
+                {{- end }}
+              {{- else }}
+          - name: {{ include "apache-nifi.fullname" $ }}-{{ $configmap.name }}
+            mountPath: {{ $configmap.mountPath }}
+            readOnly: true
+              {{- end }}
+            {{- end }}
+          {{- end }}
       - name: app-log
         image: {{ .Values.sidecar.image }}
         args: [tail, -n+1, -F, /var/log/nifi-app.log]
@@ -324,6 +340,11 @@ spec:
       - name: {{ include "apache-nifi.fullname" $ }}-{{ .name }}
         secret:
           secretName: {{ .name }}
+      {{- end }}
+      {{- range .Values.configmaps }}
+      - name: {{ include "apache-nifi.fullname" $ }}-{{ .name }}
+        configMap:
+          name: {{ .name }}
       {{- end }}
 {{- if not .Values.persistence.enabled }}
       - name: data

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -75,6 +75,10 @@ spec:
             echo "waiting for zookeeper..."
             sleep 2
           done
+{{- range $key, $value := .Values.initContainers }}
+      - name: {{ $key }}
+{{ toYaml $value | indent 8 }}
+{{- end }}
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:
         - name: {{ .Values.image.pullSecret }}
@@ -257,6 +261,9 @@ spec:
               {{- end }}
             {{- end }}
           {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 10 }}
+          {{- end }}
       - name: app-log
         image: {{ .Values.sidecar.image }}
         args: [tail, -n+1, -F, /var/log/nifi-app.log]
@@ -357,6 +364,9 @@ spec:
         emptyDir: {}
       - name: logs
         emptyDir: {}
+{{- end }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 6 }}
 {{- end }}
 {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:

--- a/values.yaml
+++ b/values.yaml
@@ -35,6 +35,15 @@ sts:
 #     - key2
 #   mountPath: /opt/nifi/secret
 
+## Useful if using any custom configmaps
+## Pass in some configmaps to use (if required)
+# configmaps:
+#   - name: myNifiConf
+#     keys:
+#       - myconf.conf
+#     mountPath: /opt/nifi/custom-config
+
+
 properties:
   # use externalSecure for when inbound SSL is provided by nginx-ingress or other external mechanism
   externalSecure: false

--- a/values.yaml
+++ b/values.yaml
@@ -177,6 +177,19 @@ nodeSelector: {}
 
 tolerations: []
 
+initContainers: {}
+  # foo-init:  # <- will be used as container name
+  #   image: "busybox:1.30.1"
+  #   imagePullPolicy: "IfNotPresent"
+  #   command: ['sh', '-c', 'echo this is an initContainer']
+  #   volumeMounts:
+#     - mountPath: /tmp/foo
+#       name: foo
+
+extraVolumeMounts: []
+
+extraVolumes: []
+
 # ------------------------------------------------------------------------------
 # Zookeeper:
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
#### What this PR does / why we need it:
@alexnuttinck 
Adds additional configuration possibilities for initContainers, extraVolumes and extraVolumeMounts which are then added to the pod-definition

#### Which issue this PR fixes
  - fixes #53

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
