### PR TITLE
Parameterize BusyBox image

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ The following table lists the configurable parameters of the nifi chart and the 
 | `jvmMemory`                                                                 | bootstrap jvm size                                                                                                 | `2g`                            |
 | **SideCar**                                                                 |
 | `sidecar.image`                                                             | Separate image for tailing each log separately                                                                     | `ez123/alpine-tini`             |
+| **BusyBox**                                                                 |
+| `busybox.image`                                                             | Separate image for initContainer that verifies zookeeper is accessible                                             | `busybox`                       |
 | **Resources**                                                               |
 | `resources`                                                                 | Pod resource requests and limits for logs                                                                          | `{}`                            |
 | **logResources**                                                            |

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -68,7 +68,7 @@ spec:
 {{- end }}
       initContainers:
       - name: zookeeper
-        image: busybox
+        image: {{ .Values.busybox.image }}
         command:
         - sh
         - -c

--- a/values.yaml
+++ b/values.yaml
@@ -131,6 +131,10 @@ jvmMemory: 2g
 sidecar:
   image: ez123/alpine-tini
 
+# Busybox image
+busybox:
+  image: busybox
+
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##


### PR DESCRIPTION
#### What this PR does / why we need it:

This PR parameterizes the BusyBox image name.  When running NiFi on a cluster without Internet access, the image name may need to include a non-default repository.

[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
