### PR TITLE
Only probe for zookeeper and cluster status if in cluster mode

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -67,6 +67,7 @@ spec:
 {{ toYaml .Values.securityContext | indent 8 }}
 {{- end }}
       initContainers:
+{{- if .Values.properties.isNode }}
       - name: zookeeper
         image: busybox
         command:
@@ -78,6 +79,7 @@ spec:
             echo "waiting for zookeeper..."
             sleep 2
           done
+{{- end }}
 {{- range $key, $value := .Values.initContainers }}
       - name: {{ $key }}
 {{ toYaml $value | indent 8 }}
@@ -205,6 +207,7 @@ spec:
             exec:
               command: ["/bin/sh", "-c", {{ .Values.postStart | quote }}]
 {{- end }}
+{{- if .Values.properties.isNode }}
         readinessProbe:
           initialDelaySeconds: 60
           periodSeconds: 20
@@ -229,6 +232,7 @@ spec:
                 jq . $NIFI_BASE_DIR/data/cluster.state
                 exit 1
               fi
+{{- end }}
         livenessProbe:
           initialDelaySeconds: 90
           periodSeconds: 60


### PR DESCRIPTION
#### What this PR does / why we need it:

If properties.isNode is false, then NiFi does not expect to connect to zookeeper and will never report itself as a ready cluster member.  So do not start the BusyBox initContainer to verify zookeeper connectivity, and do not wait for NiFi to report itself as a ready cluster member. 

- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
