### PR TITLE
Parameterize zookeeper and log image tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,10 @@ The following table lists the configurable parameters of the nifi chart and the 
 | `jvmMemory`                                                                 | bootstrap jvm size                                                                                                 | `2g`                            |
 | **SideCar**                                                                 |
 | `sidecar.image`                                                             | Separate image for tailing each log separately                                                                     | `ez123/alpine-tini`             |
+| `sidecar.tag`                                                               | Image tag                                                                                                          | `latest`                        |
 | **BusyBox**                                                                 |
 | `busybox.image`                                                             | Separate image for initContainer that verifies zookeeper is accessible                                             | `busybox`                       |
+| `busybox.tag`                                                               | Image tag                                                                                                          | `latest`                        |
 | **Resources**                                                               |
 | `resources`                                                                 | Pod resource requests and limits for logs                                                                          | `{}`                            |
 | **logResources**                                                            |

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -69,7 +69,7 @@ spec:
       initContainers:
 {{- if .Values.properties.isNode }}
       - name: zookeeper
-        image: {{ .Values.busybox.image }}
+        image: "{{ .Values.busybox.image }}:{{ .Values.busybox.tag }}"
         command:
         - sh
         - -c
@@ -317,7 +317,7 @@ spec:
 {{ toYaml .Values.extraVolumeMounts | indent 10 }}
           {{- end }}
       - name: app-log
-        image: {{ .Values.sidecar.image }}
+        image: "{{ .Values.sidecar.image }}:{{ .Values.sidecar.tag }}"
         args: [tail, -n+1, -F, /var/log/nifi-app.log]
         resources:
 {{ toYaml .Values.logresources | indent 10 }}
@@ -325,7 +325,7 @@ spec:
         - name: logs
           mountPath: /var/log
       - name: bootstrap-log
-        image: {{ .Values.sidecar.image }}
+        image: "{{ .Values.sidecar.image }}:{{ .Values.sidecar.tag }}"
         args: [tail, -n+1, -F, /var/log/nifi-bootstrap.log]
         resources:
 {{ toYaml .Values.logresources | indent 10 }}
@@ -333,7 +333,7 @@ spec:
         - name: logs
           mountPath: /var/log
       - name: user-log
-        image: {{ .Values.sidecar.image }}
+        image: "{{ .Values.sidecar.image }}:{{ .Values.sidecar.tag }}"
         args: [tail, -n+1, -F, /var/log/nifi-user.log]
         resources:
 {{ toYaml .Values.logresources | indent 10 }}

--- a/values.yaml
+++ b/values.yaml
@@ -130,10 +130,12 @@ jvmMemory: 2g
 # Separate image for tailing each log separately
 sidecar:
   image: ez123/alpine-tini
+  tag: latest
 
 # Busybox image
 busybox:
   image: busybox
+  tag: latest
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
<!--
Thank you for contributing to this repository. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
the review guidelines form the Helm repository:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR parameterizes the BusyBox and Alpine-tini image tags. This allows users to use immutable tags, which is strongly recommended in a production environment to avoid unexpected behavior upon pod rescheduling.


- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
