### PR TITLE
Replace alpine-tiny by busybox

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,8 @@ The following table lists the configurable parameters of the nifi chart and the 
 | **jvmMemory**                                                               |
 | `jvmMemory`                                                                 | bootstrap jvm size                                                                                                 | `2g`                            |
 | **SideCar**                                                                 |
-| `sidecar.image`                                                             | Separate image for tailing each log separately                                                                     | `ez123/alpine-tini`             |
-| `sidecar.tag`                                                               | Image tag                                                                                                          | `latest`                        |
-| **BusyBox**                                                                 |
-| `busybox.image`                                                             | Separate image for initContainer that verifies zookeeper is accessible                                             | `busybox`                       |
-| `busybox.tag`                                                               | Image tag                                                                                                          | `latest`                        |
+| `sidecar.image`                                                             | Separate image for tailing each log separately and checking zookeeper connectivity                                 | `busybox`                       |
+| `sidecar.tag`                                                               | Image tag                                                                                                          | `1.32.0`                        |
 | **Resources**                                                               |
 | `resources`                                                                 | Pod resource requests and limits for logs                                                                          | `{}`                            |
 | **logResources**                                                            |

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -74,7 +74,7 @@ spec:
       initContainers:
 {{- if .Values.properties.isNode }}
       - name: zookeeper
-        image: "{{ .Values.busybox.image }}:{{ .Values.busybox.tag }}"
+        image: "{{ .Values.sidecar.image }}:{{ .Values.sidecar.tag }}"
         command:
         - sh
         - -c

--- a/values.yaml
+++ b/values.yaml
@@ -131,15 +131,10 @@ ingress:
 # Amount of memory to give the NiFi java heap
 jvmMemory: 2g
 
-# Separate image for tailing each log separately
+# Separate image for tailing each log separately and checking zookeeper connectivity
 sidecar:
-  image: ez123/alpine-tini
-  tag: latest
-
-# Busybox image
-busybox:
   image: busybox
-  tag: latest
+  tag: "1.32.0"
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
<!--
Thank you for contributing to this repository. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
the review guidelines form the Helm repository:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
I suggest replacing the alpine-tiny docker image by busybox for the zookeeper connection check pod.
* ez123/alpine-tini has not been updated for almost 2 years.
* There is no need to pull an additional image like alpine-tiny given that busybox is already pulled and used for logging pods.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
