### PR TITLE
Fix ca port variable

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -93,7 +93,7 @@ spec:
         - bash
         - -c
         - |
-          CA_ADDRESS="{{ template "ca.server" . }}:{{ .Values.ca.port }}"
+          CA_ADDRESS="{{ template "ca.server" . }}:{{ .Values.ca.service.port }}"
           until echo "" | timeout -t 2 openssl s_client -connect "${CA_ADDRESS}"; do
             # Checking if ca server using nifi-toolkit is up
             echo "Waiting for CA to be avaiable at ${CA_ADDRESS}"
@@ -114,7 +114,7 @@ spec:
             --subjectAlternativeNames {{ template "apache-nifi.fullname" . }}.{{ .Release.Namespace }}.svc \
 {{- end }}
             -D "CN=$(hostname -f), OU=NIFI" \
-            -p {{ .Values.ca.port }}
+            -p {{ .Values.ca.service.port }}
 
           # Generate client certificate for browser with webProxyHost or service name as alternate names to access nifi web ui
           mkdir -p /data/config-data/certs/admin
@@ -128,7 +128,7 @@ spec:
 {{- else }}
             --subjectAlternativeNames {{ template "apache-nifi.fullname" . }}.{{ .Release.Namespace }}.svc \
 {{- end }}
-            -p {{ .Values.ca.port }} \
+            -p {{ .Values.ca.service.port }} \
             -D "CN={{ .Values.ca.admin.cn }}, OU=NIFI" \
             -T PKCS12
 

--- a/values.yaml
+++ b/values.yaml
@@ -243,7 +243,8 @@ ca:
   ## If true, enable the nifi-toolkit certificate authority
   enabled: false
   server: ""
-  port: 9090
+  service:
+    port: 9090
   token: sixteenCharacters
   admin:
     cn: admin


### PR DESCRIPTION
<!--
Thank you for contributing to this repository. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
the review guidelines form the Helm repository:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:
In the CA chart the `port` variable doesn't exist. `app_port` and `service.port` do. Since we will be wanting to point at the service with our helm nifi chart, we need to change the `ca.port` stuff to `ca.service.port`.

Here is the line in the ca chart: https://github.com/cetic/helm-nifi/blob/develop/charts/ca/values.yaml#L14

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:


#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
