### PR TITLE
Add custom lib path configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The following table lists the configurable parameters of the nifi chart and the 
 | `properties.siteToSite.port`                                                | Site to Site properties Secure port                                                                                | `10000`                         |
 | `properties.siteToSite.authorizer`                                          |                                                                                                                    | `managed-authorizer`            |
 | `properties.safetyValve`                                                    | Map of explicit 'property: value' pairs that overwrite other configuration                                         | `nil`                           |
+| `properties.customLibPath`                                                  | Path of the custom libraries folder                                                                                | `nil`                           |
 | **nifi user authentication**                                                |
 | `auth.admin`                                                                | Default admin identity                                                                                             | ` CN=admin, OU=NIFI`            |
 | `auth.ldap.enabled`                                                         | Enable User auth via ldap                                                                                          | `false`                         |

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -33,6 +33,7 @@ nifi.templates.directory=../data/templates
 nifi.ui.banner.text=
 nifi.ui.autorefresh.interval=30 sec
 nifi.nar.library.directory=./lib
+nifi.nar.library.directory.custom={{.Values.properties.customLibPath}}
 nifi.nar.working.directory=./work/nar/
 nifi.documentation.working.directory=./work/docs/components
 

--- a/values.yaml
+++ b/values.yaml
@@ -68,6 +68,9 @@ properties:
     # listen to loopback interface so "kubectl port-forward ..." works
     nifi.web.http.network.interface.lo: lo
 
+  ## Include aditional processors
+  # customLibPath: "/opt/configuration_resources/custom_lib"
+
 ## Include additional libraries in the Nifi containers by using the postStart handler
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/
 # postStart: /opt/nifi/psql; wget -P /opt/nifi/psql https://jdbc.postgresql.org/download/postgresql-42.2.6.jar


### PR DESCRIPTION
This PR adds an option to specify a custom lib path for Nifi, for e.g. adding custom processors.

Nifi documentation on this feature: https://cwiki.apache.org/confluence/display/NIFI/2.+Before+You+Begin#id-2.BeforeYouBegin-customNARs

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [X] Variables are documented in the README.md

Signed-off-by: Sébastien Dupont <sebastien.dupont@cetic.be>
