### PR TITLE
Add openshift support

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: nifi
-version: 0.5.4
+version: 0.5.5
 appVersion: 1.12.1
 description: Apache NiFi is a software project from the Apache Software Foundation designed to automate the flow of data between software systems.
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -27,5 +27,5 @@ dependencies:
     repository: https://dysnix.github.io/charts/
     condition: registry.enabled
   - name: ca
-    version: 1.0.0
+    version: 1.0.1
     condition: ca.enabled

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ The following table lists the configurable parameters of the nifi chart and the 
 | `securityContext.runAsUser`                                                 | nifi Docker User                                                                                                   | `1000`                          |
 | `securityContext.fsGroup`                                                   | nifi Docker Group                                                                                                  | `1000`                          |
 | **sts**                                                                     |
+| `sts.serviceAccount.enabled`    | If true, a service account will be created and used by the statefulset | `false` |
+| `sts.serviceAccount.name`       | When set, the set name will be used as the service account name. If a value is not provided a name will be generated based on Chart options | `nil` |
 | `sts.podManagementPolicy`                                                   | Parallel podManagementPolicy                                                                                       | `Parallel`                      |
 | `sts.AntiAffinity`                                                          | Affinity for pod assignment                                                                                        | `soft`                          |
 | `sts.pod.annotations`                                                       | Pod template annotations                                                                                           | `security.alpha.kubernetes.io/sysctls: net.ipv4.ip_local_port_range=10000 65000`                          |
@@ -177,6 +179,11 @@ The following table lists the configurable parameters of the nifi chart and the 
 | `env`                                                                       | Additional environment variables for the nifi-container (see [spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#envvar-v1-core) for details)  | `[]`                            |
 | **extraContainers**                                                         |
 | `extraContainers`                                                           | Additional container-specifications that should run within the pod (see [spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#container-v1-core) for details)  | `[]`                            |
+| **openshift**                                                                     |
+| `openshift.scc.enabled`                                                     | If true, a openshift security context will be created permitting to run the statefulset as AnyUID | `false` |
+| `openshift.route.enabled`                                                   | If true, a openshift route will be created. This option cannot be used together with Ingress as a route object replaces the Ingress. The property `properties.externalSecure` will configure the route in edge termination mode, the default is passthrough. The property `properties.httpsPort` has to be set if the cluster is intended to work with SSL termination | `false` |
+| `openshift.route.host`                                                      | The hostname intended to be used in order to access NiFi web interface | `nil` |
+| `openshift.route.path`                                                      | Path to access frontend, works the same way as the ingress path option | `nil` |
 | **zookeeper**                                                               |
 | `zookeeper.enabled`                                                         | If true, deploy Zookeeper                                                                                          | `true`                          |
 | `zookeeper.url`                                                             | If the Zookeeper Chart is disabled a URL and port are required to connect                                          | `nil`                           |

--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ The following table lists the configurable parameters of the nifi chart and the 
 | `ca.port`                                                                   | CA server port number                                          | `9090`                            |
 | `ca.token`                                                                  | The token to use to prevent MITM                                          | `80`                            |
 | `ca.admin.cn`                                                               | CN for admin certificate                                          | `admin`                            |
+| `ca.serviceAccount.enabled`                                                 | If true, a service account will be created and used by the deployment                                         | `false`                            |
+| `ca.serviceAccount.name`                                                 |When set, the set name will be used as the service account name. If a value is not provided a name will be generated based on Chart options | `nil` |
+| `ca.openshift.scc.enabled`                                                     | If true, an openshift security context will be created permitting to run the deployment as AnyUID | `false` |
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The following table lists the configurable parameters of the nifi chart and the 
 | `securityContext.runAsUser`                                                 | nifi Docker User                                                                                                   | `1000`                          |
 | `securityContext.fsGroup`                                                   | nifi Docker Group                                                                                                  | `1000`                          |
 | **sts**                                                                     |
-| `sts.serviceAccount.enabled`    | If true, a service account will be created and used by the statefulset | `false` |
+| `sts.serviceAccount.create`    | If true, a service account will be created and used by the statefulset | `false` |
 | `sts.serviceAccount.name`       | When set, the set name will be used as the service account name. If a value is not provided a name will be generated based on Chart options | `nil` |
 | `sts.podManagementPolicy`                                                   | Parallel podManagementPolicy                                                                                       | `Parallel`                      |
 | `sts.AntiAffinity`                                                          | Affinity for pod assignment                                                                                        | `soft`                          |
@@ -198,7 +198,7 @@ The following table lists the configurable parameters of the nifi chart and the 
 | `ca.port`                                                                   | CA server port number                                          | `9090`                            |
 | `ca.token`                                                                  | The token to use to prevent MITM                                          | `80`                            |
 | `ca.admin.cn`                                                               | CN for admin certificate                                          | `admin`                            |
-| `ca.serviceAccount.enabled`                                                 | If true, a service account will be created and used by the deployment                                         | `false`                            |
+| `ca.serviceAccount.create`                                                 | If true, a service account will be created and used by the deployment                                         | `false`                            |
 | `ca.serviceAccount.name`                                                 |When set, the set name will be used as the service account name. If a value is not provided a name will be generated based on Chart options | `nil` |
 | `ca.openshift.scc.enabled`                                                     | If true, an openshift security context will be created permitting to run the deployment as AnyUID | `false` |
 

--- a/charts/ca/Chart.yaml
+++ b/charts/ca/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: ca
-version: 1.0.0
+version: 1.0.1
 # We are using the nifi version as appVersion
 appVersion: 1.11.4
 description: A Helm chart to deploy ca server to generate self-signed certificates using nifi-toolkit.

--- a/charts/ca/templates/_helpers.tpl
+++ b/charts/ca/templates/_helpers.tpl
@@ -23,3 +23,14 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Set the service account name
+*/}}
+{{- define "ca.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "ca.fullname" .) .Values.serviceAccount.name }}-sa
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/ca/templates/deployment.yaml
+++ b/charts/ca/templates/deployment.yaml
@@ -63,6 +63,7 @@ spec:
         name: volume-permissions
         resources: {}
         securityContext:
+          runAsUser: 0
           allowPrivilegeEscalation: false
           capabilities: {}
           privileged: false

--- a/charts/ca/templates/deployment.yaml
+++ b/charts/ca/templates/deployment.yaml
@@ -20,6 +20,13 @@ spec:
         app: {{ template "ca.name" . }}-ca
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.serviceAccount.enabled -}}
+        {{- if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+        {{- else }}
+      serviceAccountName: {{ template "ca.fullname" . }}-sa
+        {{- end }}
+      {{- end }}
       containers:
       - name: ca
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}

--- a/charts/ca/templates/deployment.yaml
+++ b/charts/ca/templates/deployment.yaml
@@ -20,13 +20,7 @@ spec:
         app: {{ template "ca.name" . }}-ca
         release: {{ .Release.Name }}
     spec:
-      {{- if .Values.serviceAccount.enabled -}}
-        {{- if .Values.serviceAccount.name }}
-      serviceAccountName: {{ .Values.serviceAccount.name }}
-        {{- else }}
-      serviceAccountName: {{ template "ca.fullname" . }}-sa
-        {{- end }}
-      {{- end }}
+      serviceAccountName: {{ include "ca.serviceAccountName" . }}
       containers:
       - name: ca
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}

--- a/charts/ca/templates/scc.yaml
+++ b/charts/ca/templates/scc.yaml
@@ -2,6 +2,11 @@
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
+  labels:
+    app: {{ template "ca.name" . }}-ca
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
   annotations:
     kubernetes.io/description: nifi provides all features of the restricted SCC but
       allows users to run with any UID and any GID.

--- a/charts/ca/templates/scc.yaml
+++ b/charts/ca/templates/scc.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.openshift.scc.enabled -}}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: nifi provides all features of the restricted SCC but
+      allows users to run with any UID and any GID.
+  name: {{ template "ca.fullname" . }}-scc
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+  {{- if .Values.serviceAccount.name }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.serviceAccount.name }}
+  {{- else }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ template "ca.fullname" . }}-sa
+  {{- end }}
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+{{- end }}

--- a/charts/ca/templates/scc.yaml
+++ b/charts/ca/templates/scc.yaml
@@ -29,11 +29,7 @@ seLinuxContext:
 supplementalGroups:
   type: RunAsAny
 users:
-  {{- if .Values.serviceAccount.name }}
-- system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.serviceAccount.name }}
-  {{- else }}
-- system:serviceaccount:{{ .Release.Namespace }}:{{ template "ca.fullname" . }}-sa
-  {{- end }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ include "ca.serviceAccountName" . }}
 volumes:
 - configMap
 - downwardAPI

--- a/charts/ca/templates/serviceaccount.yaml
+++ b/charts/ca/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- if .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}
+  {{- else }}
+  name:  {{ template "ca.fullname" . }}-sa
+  {{- end }}
+{{- end }}

--- a/charts/ca/templates/serviceaccount.yaml
+++ b/charts/ca/templates/serviceaccount.yaml
@@ -1,10 +1,11 @@
-{{- if .Values.serviceAccount.enabled -}}
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  {{- if .Values.serviceAccount.name }}
-  name: {{ .Values.serviceAccount.name }}
-  {{- else }}
-  name:  {{ template "ca.fullname" . }}-sa
-  {{- end }}
+  labels:
+    app: {{ template "ca.name" . }}-ca
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  name: {{ include "ca.serviceAccountName" . }}
 {{- end }}

--- a/charts/ca/values.yaml
+++ b/charts/ca/values.yaml
@@ -51,7 +51,7 @@ securityContext:
   runAsUser: 1000
 
 serviceAccount:
-  enabled: false
+  create: false
   #name: nifi-ca
 
 ## Openshift support

--- a/charts/ca/values.yaml
+++ b/charts/ca/values.yaml
@@ -49,3 +49,13 @@ token: sixteenCharacters
 securityContext:
   fsGroup: 1000
   runAsUser: 1000
+
+serviceAccount:
+  enabled: false
+  #name: nifi-ca
+
+## Openshift support
+## Use the following varables in order to enable Route and Security Context Constraint creation
+openshift:
+  scc:
+    enabled: false

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -79,3 +79,14 @@ Create ca.server
 {{- printf "%s" .Values.ca.server }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Set the service account name
+*/}}
+{{- define "apache-nifi.serviceAccountName" -}}
+{{- if .Values.sts.serviceAccount.create }}
+{{- default (include "apache-nifi.fullname" .) .Values.sts.serviceAccount.name }}-sa
+{{- else }}
+{{- default "default" .Values.sts.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/templates/route.yaml
+++ b/templates/route.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.openshift.route.enabled -}}
+{{- $fullName := include "apache-nifi.fullname" . -}}
+{{- $ingressPath := .Values.openshift.route.path -}}
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: {{ template "apache-nifi.fullname" . }}-route
+spec:
+  {{- if .Values.openshift.route.host }}
+  host: {{ .Values.openshift.route.host }}
+  {{- end }}
+  {{- if .Values.openshift.route.host }}
+  path: {{ $ingressPath }}
+  {{- end }}
+  to:
+    kind: Service
+    name: {{ $fullName }}
+    weight: 100
+  port:
+{{- if .Values.properties.clusterSecure }}
+    targetPort: {{ .Values.service.httpsPort }}
+  tls:
+    {{- if .Values.properties.externalSecure }}
+    termination: edge
+    {{- else }}
+    termination: passthrough
+    {{- end }}
+    insecureEdgeTerminationPolicy: Redirect
+{{- else }}
+    targetPort: {{ .Values.service.httpPort }}
+{{- end }}
+{{- end }}

--- a/templates/route.yaml
+++ b/templates/route.yaml
@@ -4,6 +4,11 @@
 kind: Route
 apiVersion: route.openshift.io/v1
 metadata:
+  labels:
+    app: {{ include "apache-nifi.name" . | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
   name: {{ template "apache-nifi.fullname" . }}-route
 spec:
   {{- if .Values.openshift.route.host }}

--- a/templates/route.yaml
+++ b/templates/route.yaml
@@ -9,7 +9,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-  name: {{ template "apache-nifi.fullname" . }}-route
+  name: {{ template "apache-nifi.fullname" . }}
 spec:
   {{- if .Values.openshift.route.host }}
   host: {{ .Values.openshift.route.host }}

--- a/templates/route.yaml
+++ b/templates/route.yaml
@@ -18,7 +18,7 @@ spec:
     weight: 100
   port:
 {{- if .Values.properties.clusterSecure }}
-    targetPort: {{ .Values.service.httpsPort }}
+    targetPort: https
   tls:
     {{- if .Values.properties.externalSecure }}
     termination: edge
@@ -27,6 +27,6 @@ spec:
     {{- end }}
     insecureEdgeTerminationPolicy: Redirect
 {{- else }}
-    targetPort: {{ .Values.service.httpPort }}
+    targetPort: http
 {{- end }}
 {{- end }}

--- a/templates/scc.yaml
+++ b/templates/scc.yaml
@@ -2,8 +2,13 @@
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
+  labels:
+    app: {{ include "apache-nifi.name" . | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
   annotations:
-    kubernetes.io/description: nifi provides all features of the restricted SCC but
+    kubernetes.io/description: {{ template "apache-nifi.fullname" . }}-scc provides all features of the restricted SCC but
       allows users to run with any UID and any GID.
   name: {{ template "apache-nifi.fullname" . }}-scc
 allowHostDirVolumePlugin: false
@@ -29,11 +34,7 @@ seLinuxContext:
 supplementalGroups:
   type: RunAsAny
 users:
-  {{- if .Values.sts.serviceAccount.name }}
-- system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.sts.serviceAccount.name }}
-  {{- else }}
-- system:serviceaccount:{{ .Release.Namespace }}:{{ template "apache-nifi.fullname" . }}-sa
-  {{- end }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ include "apache-nifi.serviceAccountName" . }}
 volumes:
 - configMap
 - downwardAPI

--- a/templates/scc.yaml
+++ b/templates/scc.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.openshift.scc.enabled -}}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: nifi provides all features of the restricted SCC but
+      allows users to run with any UID and any GID.
+  name: {{ template "apache-nifi.fullname" . }}-scc
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: 10
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+  {{- if .Values.sts.serviceAccount.name }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ .Values.sts.serviceAccount.name }}
+  {{- else }}
+- system:serviceaccount:{{ .Release.Namespace }}:{{ template "apache-nifi.fullname" . }}-sa
+  {{- end }}
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+{{- end }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -1,10 +1,11 @@
-{{- if .Values.sts.serviceAccount.enabled -}}
+{{- if .Values.sts.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  {{- if .Values.sts.serviceAccount.name }}
-  name: {{ .Values.sts.serviceAccount.name }}
-  {{- else }}
-  name:  {{ template "apache-nifi.fullname" . }}-sa
-  {{- end }}
+  labels:
+    app: {{ include "apache-nifi.name" . | quote }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+  name: {{ include "apache-nifi.serviceAccountName" . }}
 {{- end }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.sts.serviceAccount.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  {{- if .Values.sts.serviceAccount.name }}
+  name: {{ .Values.sts.serviceAccount.name }}
+  {{- else }}
+  name:  {{ template "apache-nifi.fullname" . }}-sa
+  {{- end }}
+{{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -31,6 +31,13 @@ spec:
         release: {{ .Release.Name | quote }}
         heritage: {{ .Release.Service | quote }}
     spec:
+      {{- if .Values.sts.serviceAccount.enabled -}}
+        {{- if .Values.sts.serviceAccount.name }}
+      serviceAccountName: {{ .Values.sts.serviceAccount.name }}
+        {{- else }}
+      serviceAccountName: {{ template "apache-nifi.fullname" . }}-sa
+        {{- end }}
+      {{- end }}
       {{- if eq .Values.sts.AntiAffinity "hard"}}
       affinity:
         podAntiAffinity:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -31,13 +31,7 @@ spec:
         release: {{ .Release.Name | quote }}
         heritage: {{ .Release.Service | quote }}
     spec:
-      {{- if .Values.sts.serviceAccount.enabled -}}
-        {{- if .Values.sts.serviceAccount.name }}
-      serviceAccountName: {{ .Values.sts.serviceAccount.name }}
-        {{- else }}
-      serviceAccountName: {{ template "apache-nifi.fullname" . }}-sa
-        {{- end }}
-      {{- end }}
+      serviceAccountName: {{ include "apache-nifi.serviceAccountName" . }}
       {{- if eq .Values.sts.AntiAffinity "hard"}}
       affinity:
         podAntiAffinity:

--- a/values.yaml
+++ b/values.yaml
@@ -29,6 +29,9 @@ sts:
     annotations:
       security.alpha.kubernetes.io/sysctls: net.ipv4.ip_local_port_range=10000 65000
       #prometheus.io/scrape: "true"      
+  serviceAccount:
+    enabled: false
+    #name: nifi
 
 ## Useful if using any custom secrets
 ## Pass in some secrets to use (if required)
@@ -238,6 +241,16 @@ terminationGracePeriodSeconds: 30
 
 ## Extra environment variables that will be pass onto deployment pods
 env: []
+
+## Openshift support
+## Use the following varables in order to enable Route and Security Context Constraint creation
+openshift:
+  scc:
+    enabled: false
+  route:
+    enabled: false
+    #host: www.test.com
+    #path: /nifi
 
 # ca server details
 # Setting this true would create a nifi-toolkit based ca server

--- a/values.yaml
+++ b/values.yaml
@@ -30,7 +30,7 @@ sts:
       security.alpha.kubernetes.io/sysctls: net.ipv4.ip_local_port_range=10000 65000
       #prometheus.io/scrape: "true"      
   serviceAccount:
-    enabled: false
+    create: false
     #name: nifi
 
 ## Useful if using any custom secrets
@@ -265,7 +265,7 @@ ca:
   admin:
     cn: admin
   serviceAccount:
-    enabled: false
+    create: false
     #name: nifi-ca
   openshift:
     scc:

--- a/values.yaml
+++ b/values.yaml
@@ -264,6 +264,12 @@ ca:
   token: sixteenCharacters
   admin:
     cn: admin
+  serviceAccount:
+    enabled: false
+    #name: nifi-ca
+  openshift:
+    scc:
+      enabled: false
 
 # ------------------------------------------------------------------------------
 # Zookeeper:


### PR DESCRIPTION
#### What this PR does / why we need it:

* Add Security Context Constraint support (SCC)
    - Needed in order to run the Pods with arbitrary users in openshift
* Add Route support
    - Routes replace Ingress in Openshift. While it is possible to use Ingress objects in Openshift, Routes offer support to some specific features
* Add ServiceAccount to satefulset
    - SCC configurations require a target service account in order to set the correct secure context

#### Which issue this PR fixes
  - fixes #84 

#### Special notes for your reviewer:
The chart was tested on an Openshift 4.5 environment.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
