### PR TITLE
Add nifi nar autoload directory property

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: nifi
-version: 0.5.4
+version: 0.5.5
 appVersion: 1.12.1
 description: Apache NiFi is a software project from the Apache Software Foundation designed to automate the flow of data between software systems.
 keywords:

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -34,6 +34,7 @@ nifi.ui.banner.text=
 nifi.ui.autorefresh.interval=30 sec
 nifi.nar.library.directory=./lib
 nifi.nar.library.directory.custom={{.Values.properties.customLibPath}}
+nifi.nar.library.autoload.directory=./extensions
 nifi.nar.working.directory=./work/nar/
 nifi.documentation.working.directory=./work/docs/components
 


### PR DESCRIPTION
#### What this PR does / why we need it:
Adding `nifi.nar.library.autoload.directory` the property to nifi.properties to allow autoreloading NAR files which allows the addition of custom processors without requiring a nifi restart. See [this page](https://www.nifi.rocks/auto-loading-extensions/) for more info.

#### Which issue this PR fixes
None

#### Special notes for your reviewer:
None

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [ ] Variables are documented in the README.md
