### PR TITLE
Multiple fixes related to secure clusters

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: nifi
-version: 0.5.4
+version: 0.5.5
 appVersion: 1.12.1
 description: Apache NiFi is a software project from the Apache Software Foundation designed to automate the flow of data between software systems.
 keywords:

--- a/configs/nifi.properties
+++ b/configs/nifi.properties
@@ -151,11 +151,11 @@ nifi.sensitive.props.provider=BC
 nifi.sensitive.props.additional.keys=
 
 nifi.security.keystore=
-nifi.security.keystoreType=jks
+nifi.security.keystoreType=
 nifi.security.keystorePasswd=
 nifi.security.keyPasswd=
 nifi.security.truststore=
-nifi.security.truststoreType=jks
+nifi.security.truststoreType=
 nifi.security.truststorePasswd=
 nifi.security.needClientAuth={{.Values.properties.needClientAuth}}
 nifi.security.user.authorizer={{.Values.properties.authorizer}}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -2,7 +2,11 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "apache-nifi.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- if .Values.properties.clusterSecure -}}
+{{- $ingressPort := .Values.service.httpsPort -}}
+{{- else }}
 {{- $ingressPort := .Values.service.httpPort -}}
+{{- end }}
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -188,9 +188,11 @@ spec:
 {{- if .Values.properties.clusterSecure }}
           # Update nifi.properties for security properties
           prop_replace nifi.web.https.host ${FQDN}
+          prop_replace nifi.security.keystoreType jks
           prop_replace nifi.security.keystore   ${NIFI_HOME}/config-data/certs/keystore.jks
           prop_replace nifi.security.keystorePasswd     $(jq -r .keyStorePassword ${NIFI_HOME}/config-data/certs/config.json)
           prop_replace nifi.security.keyPasswd          $(jq -r .keyPassword ${NIFI_HOME}/config-data/certs/config.json)
+          prop_replace nifi.security.truststoreType jks
           prop_replace nifi.security.truststore   ${NIFI_HOME}/config-data/certs/truststore.jks
           prop_replace nifi.security.truststorePasswd   $(jq -r .trustStorePassword ${NIFI_HOME}/config-data/certs/config.json)
 

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -50,7 +50,7 @@ spec:
                podAffinityTerm:
                  labelSelector:
                     matchExpressions:
-                      - key: "component"
+                      - key: "app"
                         operator: In
                         values:
                          - {{ include "apache-nifi.name" . | quote }}


### PR DESCRIPTION
#### What this PR does / why we need it:

- The Ingress definition was using the httpPort by default instead of the httpsPort when the cluster was installed in secure mode.
-  Leave all the security configurations blank in nifi.properties by default.
- Set the keystore/truststore types to jks _only when clusterSecure is enabled_.
-  Corrected the label key for the soft antiAffinity configuration.


<!--
Thank you for contributing to this repository. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
the review guidelines form the Helm repository:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #77
  - has some *partial* work towards #72 (this one still needs the ingress controller to know that the backend is using HTTPS instead of HTTP, I am not aware of any ingress-agnostic way to specify that)

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
