### PR TITLE
Added Extra containers creation from values.yaml to templates/statefu…

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -150,6 +150,9 @@ spec:
         - name: {{ .Values.image.pullSecret }}
       {{- end }}
       containers:
+{{- if .Values.extraContainers }}
+{{- toYaml .Values.extraContainers | nindent 6 }}
+{{- end }}
       - name: server
         imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"


### PR DESCRIPTION
#### What this PR does / why we need it:
This pull requests allows enables extraContainers to be read from the values.yaml to templates/statefulset.yaml so that side-containers are created alongside the server container

#### Which issue this PR fixes
* no issues found

#### Special notes for your reviewer:
Added 3 lines in statefulset.yaml to read the extraContainers variable in values.yaml. This change should allow any number of containers to be executed alongside the server container

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
- [x] Variables are documented in the README.md
