### PR TITLE
Stale issues triage

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "30 1 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has not seen recent activity. Remove stale label or comment or this will be closed.'
+        #stale-pr-message: 'Stale pull request message'
+        stale-issue-label: 'stale'
+        #stale-pr-label: 'no-pr-activity'
+        exempt-issue-labels: 'enhancement,bug,help wanted,'
+        debug-only: true


### PR DESCRIPTION
Add scheduled job to mark issues as stale and close stale issues.

Ref: https://github.com/actions/stale

#### Special notes for your reviewer:

Current configuration: 

* dry-run mode
* only tags issues with `stale` label and add info message, does not close them
  * except issues tagged with enhancement,bug,help wanted
* nothing on the PR