### PR TITLE
Fix offloading nodes

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: nifi
-version: 0.6.4
+version: 0.6.5
 appVersion: 1.12.1
 description: Apache NiFi is a software project from the Apache Software Foundation designed to automate the flow of data between software systems.
 keywords:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -250,6 +250,15 @@ spec:
               echo "disconnecting node ${nnid}"
               ${NIFI_TOOLKIT_HOME}/bin/cli.sh nifi disconnect-node -nnid $nnid -u ${baseUrl} ${secureArgs}
               echo ""
+              echo "get a connected node"
+              connectedNode=$(jq -r 'first(.cluster.nodes[] | select(.status=="CONNECTED")) | .address' nodes.json)
+              {{- if .Values.properties.clusterSecure }}
+              baseUrl=https://${connectedNode}:{{ .Values.properties.httpsPort }}
+              {{- else }}
+              baseUrl=http://${connectedNode}:{{ .Values.properties.httpPort }}
+              {{- end }}
+              echo baseUrl ${baseUrl}
+              echo ""
               echo "wait until node has state 'DISCONNECTED'"
               while [[ "${node_state}" != "DISCONNECTED" ]]; do
                   sleep 1

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -251,7 +251,7 @@ spec:
               ${NIFI_TOOLKIT_HOME}/bin/cli.sh nifi disconnect-node -nnid $nnid -u ${baseUrl} ${secureArgs}
               echo ""
               echo "get a connected node"
-              connectedNode=$(jq -r 'first(.cluster.nodes[] | select(.status=="CONNECTED")) | .address' nodes.json)
+              connectedNode=$(jq -r 'first(.cluster.nodes|=sort_by(.address)| .cluster.nodes[] | select(.status=="CONNECTED")) | .address' nodes.json)
               {{- if .Values.properties.clusterSecure }}
               baseUrl=https://${connectedNode}:{{ .Values.properties.httpsPort }}
               {{- else }}


### PR DESCRIPTION
#### What this PR does / why we need it:
When you scale down the statefulset the offload process failed after the disconnecting call.
After disconnecting the node, further requests (check for DISCONNECTED state, offloading and deleting) are done on the node we have already disconnect and we got an error that we cannot request a disconnected node.

This PR fix that by getting the first active node and update baseUrl.

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Chart Version bumped
