### PR TITLE
Add affinity support for NiFi

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: nifi
-version: 0.6.4
+version: 0.6.5
 appVersion: 1.12.1
 description: Apache NiFi is a software project from the Apache Software Foundation designed to automate the flow of data between software systems.
 keywords:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: nifi
-version: 0.6.5
+version: 0.7.2
 appVersion: 1.12.1
 description: Apache NiFi is a software project from the Apache Software Foundation designed to automate the flow of data between software systems.
 keywords:

--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ The following table lists the configurable parameters of the nifi chart and the 
 | `resources`                                                                 | Pod resource requests and limits for logs                                                                          | `{}`                            |
 | **logResources**                                                            |
 | `logresources.`                                                             | Pod resource requests and limits                                                                                   | `{}`                            |
+| **affinity**                                                                |
+| `affinity`                                                                  | Pod affinity scheduling rules                                                                                      | `{}`                            |
 | **nodeSelector**                                                            |
 | `nodeSelector`                                                              | Node labels for pod assignment                                                                                     | `{}`                            |
 | **terminationGracePeriodSeconds**                                           |

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -36,7 +36,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
 {{- end }}
       serviceAccountName: {{ include "apache-nifi.serviceAccountName" . }}
-      {{- if eq .Values.sts.AntiAffinity "hard"}}
+      {{- if eq .Values.sts.AntiAffinity "hard" }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -47,7 +47,7 @@ spec:
                     values:
                     - {{ include "apache-nifi.name" . | quote }}
               topologyKey: "kubernetes.io/hostname"
-      {{- else if eq .Values.sts.AntiAffinity "soft"}}
+      {{- else if eq .Values.sts.AntiAffinity "soft" }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -60,7 +60,11 @@ spec:
                         values:
                          - {{ include "apache-nifi.name" . | quote }}
                  topologyKey: "kubernetes.io/hostname"
-      {{- end}}
+      {{- end }}
+{{- if and .Values.affinity (and (ne .Values.sts.AntiAffinity "hard") (ne .Values.sts.AntiAffinity "soft")) }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}
 {{- if .Values.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -239,6 +239,10 @@ logresources:
     cpu: 50m
     memory: 50Mi
 
+## Enables setting your own affinity. Mutually exclusive with sts.AntiAffinity
+## You need to set the value of sts.AntiAffinity other than "soft" and "hard"
+affinity: {}
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
#### What this PR does / why we need it:
It adds support for setting your own affinity for NiFi.

Some people may want to set up their own nodeAffinities and all of the combinations of spec.affinity. The current chart doesn't allow for this. This PR adds the support to use your own Pod affinity provided you don't choose the default one (sts.AntiAffinity).

#### Which issue this PR fixes
  - fixes #122

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
