### PR TITLE
Add hostAliases support for NiFi

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: nifi
-version: 0.6.4
+version: 0.6.5
 appVersion: 1.12.1
 description: Apache NiFi is a software project from the Apache Software Foundation designed to automate the flow of data between software systems.
 keywords:

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The following table lists the configurable parameters of the nifi chart and the 
 | `sts.podManagementPolicy`                                                   | Parallel podManagementPolicy                                                                                       | `Parallel`                      |
 | `sts.AntiAffinity`                                                          | Affinity for pod assignment                                                                                        | `soft`                          |
 | `sts.pod.annotations`                                                       | Pod template annotations                                                                                           | `security.alpha.kubernetes.io/sysctls: net.ipv4.ip_local_port_range=10000 65000`                          |
+| `sts.hostAliases    `                                                       | Add entries to Pod /etc/hosts                                                                                      | `[]`                            |
 | **secrets**
 | `secrets`                                                                   | Pass any secrets to the nifi pods. The secret can also be mounted to a specific path if required.                  | `nil`                           |
 | **configmaps**

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -35,6 +35,10 @@ spec:
       hostNetwork: {{ .Values.sts.useHostNetwork }}
       dnsPolicy: ClusterFirstWithHostNet
 {{- end }}
+{{- if .Values.sts.hostAliases }}
+      hostAliases:
+{{ toYaml .Values.sts.hostAliases | indent 8 }}
+{{- end }}
       serviceAccountName: {{ include "apache-nifi.serviceAccountName" . }}
       {{- if eq .Values.sts.AntiAffinity "hard"}}
       affinity:

--- a/values.yaml
+++ b/values.yaml
@@ -42,6 +42,11 @@ sts:
   serviceAccount:
     create: false
     #name: nifi
+  hostAliases: []
+#    - ip: "1.2.3.4"
+#      hostnames:
+#        - example.com
+#        - example
 
 ## Useful if using any custom secrets
 ## Pass in some secrets to use (if required)


### PR DESCRIPTION
#### What this PR does / why we need it:
It adds support for adding custom entries to the /etc/hosts file thanks to [spec.hostAliases](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/).

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
