### PR TITLE
Add imagePullPolicy support for NiFi sidecars

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: nifi
-version: 0.6.4
+version: 0.6.5
 appVersion: 1.12.1
 description: Apache NiFi is a software project from the Apache Software Foundation designed to automate the flow of data between software systems.
 keywords:

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ The following table lists the configurable parameters of the nifi chart and the 
 | **SideCar**                                                                 |
 | `sidecar.image`                                                             | Separate image for tailing each log separately and checking zookeeper connectivity                                 | `busybox`                       |
 | `sidecar.tag`                                                               | Image tag                                                                                                          | `1.32.0`                        |
+| `sidecar.imagePullPolicy`                                                   | Image imagePullPolicy                                                                                              | `IfNotPresent`                  |
 | **Resources**                                                               |
 | `resources`                                                                 | Pod resource requests and limits for logs                                                                          | `{}`                            |
 | **logResources**                                                            |

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -79,6 +79,7 @@ spec:
       initContainers:
 {{- if .Values.properties.isNode }}
       - name: zookeeper
+        imagePullPolicy: {{ .Values.sidecar.imagePullPolicy | default "Always" | quote }}
         image: "{{ .Values.sidecar.image }}:{{ .Values.sidecar.tag }}"
         command:
         - sh
@@ -446,6 +447,7 @@ spec:
 {{ toYaml .Values.extraVolumeMounts | indent 10 }}
           {{- end }}
       - name: app-log
+        imagePullPolicy: {{ .Values.sidecar.imagePullPolicy | default "Always" | quote }}
         image: "{{ .Values.sidecar.image }}:{{ .Values.sidecar.tag }}"
         args: [tail, -n+1, -F, /var/log/nifi-app.log]
         resources:
@@ -454,6 +456,7 @@ spec:
         - name: logs
           mountPath: /var/log
       - name: bootstrap-log
+        imagePullPolicy: {{ .Values.sidecar.imagePullPolicy | default "Always" | quote }}
         image: "{{ .Values.sidecar.image }}:{{ .Values.sidecar.tag }}"
         args: [tail, -n+1, -F, /var/log/nifi-bootstrap.log]
         resources:
@@ -462,6 +465,7 @@ spec:
         - name: logs
           mountPath: /var/log
       - name: user-log
+        imagePullPolicy: {{ .Values.sidecar.imagePullPolicy | default "Always" | quote }}
         image: "{{ .Values.sidecar.image }}:{{ .Values.sidecar.tag }}"
         args: [tail, -n+1, -F, /var/log/nifi-user.log]
         resources:

--- a/values.yaml
+++ b/values.yaml
@@ -176,6 +176,7 @@ jvmMemory: 2g
 sidecar:
   image: busybox
   tag: "1.32.0"
+  imagePullPolicy: "IfNotPresent"
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
#### What this PR does / why we need it:
It adds imagePullPolicy support for NiFi sidecars. Sometimes, people do not want to pull the same images from the image registry. This PR adds the option to change it.

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
