### PR TITLE
Basic test in Minikube

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,13 @@
 name: Test
 
-on: [push]
-
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+    
 jobs:
   example:
     name: Minikube installation - Basic test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,10 @@
-name: Example workflow
+name: Test
 
 on: [push]
 
 jobs:
   example:
-    name: Example Minikube-Kubernetes Cluster interaction
+    name: Minikube installation - Basic test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -27,8 +27,6 @@ jobs:
           helm repo update
           helm dep up          
       - name: Install Nifi
-        run: helm install --name nifi .
+        run: helm install nifi .
       - name: Check deployment status
         run: kubectl wait --for=condition=Ready pod/nifi-0 --timeout=10m
-
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,20 @@ jobs:
           minikube version: 'v1.20.0'
           kubernetes version: 'v1.20.2'
           #github token: ${{ secrets.GITHUB_TOKEN }}          
-      - run: minikube addons list
-      - name: Interact with the cluster
-        run: kubectl get nodes
+      #- run: minikube addons list
+      #- name: Interact with the cluster
+      #  run: kubectl get nodes
+      - name: Checkout code
+        uses: actions/checkout@v1
+      - name: Install dependencies
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add dysnix https://dysnix.github.io/charts/
+          helm repo update
+          helm dep up          
+      - name: Install Nifi
+        run: helm install --name nifi .
+      - name: Check deployment status
+        run: kubectl wait --for=condition=Ready pod/nifi-0 --timeout=10m
+
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,5 @@ jobs:
         run: helm install nifi .
       - name: Check deployment status
         run: kubectl wait --for=condition=Ready pod/nifi-0 --timeout=10m
+      - name: Check web application is available
+        run: curl $(minikube service nifi --url)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,20 @@
+name: Example workflow
+
+on: [push]
+
+jobs:
+  example:
+    name: Example Minikube-Kubernetes Cluster interaction
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.4.1
+        with:
+          minikube version: 'v1.20.0'
+          kubernetes version: 'v1.20.2'
+          #github token: ${{ secrets.GITHUB_TOKEN }}          
+      - run: minikube addons list
+      - name: Interact with the cluster
+        run: kubectl get nodes

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Helm Chart for Apache NiFi
 
-[![CircleCI](https://circleci.com/gh/cetic/helm-nifi.svg?style=svg)](https://circleci.com/gh/cetic/helm-nifi/tree/master) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![version](https://img.shields.io/github/tag/cetic/helm-nifi.svg?label=release)
+[![CircleCI](https://circleci.com/gh/cetic/helm-nifi.svg?style=svg)](https://circleci.com/gh/cetic/helm-nifi/tree/master) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) ![version](https://img.shields.io/github/tag/cetic/helm-nifi.svg?label=release) ![test](https://github.com/cetic/helm-nifi/actions/workflows/test.yml/badge.svg)
+
 
 ## Introduction
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Add basic Minikube test for the chart: deploys it, wait for the pods to be up and `curl` the web interface url. 

#### Which issue this PR fixes

It is a first step towards automating testing for the chart (#91).