### PR TITLE
Re-enable safetyValve if OIDC is not enabled / clusterSecure false

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: nifi
-version: 0.7.5
+version: 0.7.8
 appVersion: 1.12.1
 description: Apache NiFi is a software project from the Apache Software Foundation designed to automate the flow of data between software systems.
 keywords:

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -218,6 +218,8 @@ spec:
           prop_replace nifi.security.truststoreType jks
           prop_replace nifi.security.truststore   ${NIFI_HOME}/config-data/certs/truststore.jks
           prop_replace nifi.security.truststorePasswd   $(jq -r .trustStorePassword ${NIFI_HOME}/config-data/certs/config.json)
+{{- end }}
+{{- end }}
 
 {{- if .Values.properties.webProxyHost }}
           # Update nifi.properties for web ui proxy hostname
@@ -226,14 +228,10 @@ spec:
           prop_replace nifi.web.proxy.host {{ template "apache-nifi.fullname" . }}.{{ .Release.Namespace }}.svc
 {{- end }}
 
-
-{{- end }}
-
 {{- if .Values.properties.safetyValve }}
   {{- range $prop, $val := .Values.properties.safetyValve }}
           prop_replace {{ $prop }} "{{ $val }}" nifi.properties
   {{- end }}
-{{- end }}
 {{- end }}
 
 


### PR DESCRIPTION
#### What this PR does / why we need it:

If OIDC is not enabled or clusterSecure is false, then safetyValve items do not get rendered into the statefulset YAML.  Apparently commit dbc0712785298c898d80dc4d10100cacec33a102 pulled in too much.


#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed

