### PR TITLE
Update nifi to 1.15.0 & update ingress

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 name: nifi
-version: 1.0.3
-appVersion: 1.14.0
+version: 1.1.0
+appVersion: 1.15.0
 description: Apache NiFi is a software project from the Apache Software Foundation designed to automate the flow of data between software systems.
 keywords:
   - nifi

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -3,7 +3,7 @@
 {{- $fullName := include "apache-nifi.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
 {{- $ingressHttpsPort := .Values.service.httpsPort -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "apache-nifi.fullname" . }}-ingress
@@ -34,8 +34,11 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $ingressHttpsPort }}
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: {{ $ingressHttpsPort }}
   {{- end }}
 {{- end }}

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -255,12 +255,14 @@ spec:
         - name: NIFI_ZOOKEEPER_CONNECT_STRING
           value: {{ template "zookeeper.url" . }}
 {{- if not (or (.Values.auth.ldap.enabled) (.Values.auth.oidc.enabled)) }}
+        - name: NIFI_WEB_PROXY_HOST
+          value: {{ .Values.properties.webProxyHost }}
         - name: SINGLE_USER_CREDENTIALS_USERNAME
           value: {{ .Values.auth.singleUser.username }}
         - name: SINGLE_USER_CREDENTIALS_PASSWORD
           value: {{ .Values.auth.singleUser.password }}
         - name: NIFI_WEB_HTTPS_HOST
-          value: 0.0.0.0
+          value: {{ .Values.properties.webHttpsHost }}
 {{- end }}
 {{- if .Values.env }}
 {{ toYaml .Values.env | indent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 ##
 image:
   repository: apache/nifi
-  tag: "1.14.0"
+  tag: "1.15.0"
   pullPolicy: "IfNotPresent"
 
   ## Optionally specify an imagePullSecret.
@@ -74,7 +74,7 @@ properties:
   externalSecure: false
   isNode: false
   httpsPort: 8443 
-  webProxyHost: # <clusterIP>:<NodePort> (If Nifi service is NodePort or LoadBalancer)
+  webProxyHost: # If Nifi is behind a reverse proxy, set here the address you will enter in your browser
   clusterPort: 6007
   provenanceStorage: "8 GB"
   siteToSite:


### PR DESCRIPTION
Nifi has been updated to 1.15.0. This version supports the NIFI_WEB_PROXY_HOST environment variable.

The ingress has also been updated to support the latest versions of Kubernetes.