### PR TITLE
At test time, confirm web service is started and responding with expe…

### DIFF
--- a/.github/workflows/test-safetyvalve.yml
+++ b/.github/workflows/test-safetyvalve.yml
@@ -1,0 +1,45 @@
+name: Test-SafetyValve
+
+on:
+  push:
+    branches:
+    - patch/properties-no-ldap-oidc
+  pull_request:
+    branches:
+    - patch/properties-no-ldap-oidc
+    
+jobs:
+  test-safetyvalve:
+    name: Test NiFi Helm Chart SafetyValve Properties
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.4.1
+        with:
+          minikube version: 'v1.20.0'
+          kubernetes version: 'v1.20.2'
+          #github token: ${{ secrets.GITHUB_TOKEN }}          
+      #- run: minikube addons list
+      #- name: Interact with the cluster
+      #  run: kubectl get nodes
+      - name: Checkout code
+        uses: actions/checkout@v1
+      - name: Install dependencies
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add dysnix https://dysnix.github.io/charts/
+          helm repo update
+          helm dep up          
+      - name: Install Nifi
+        run: helm install nifi . -f tests/01-safetyValve-values.yaml
+      - name: Check deployment status
+        run: kubectl wait --for=condition=Ready pod/nifi-0 --timeout=20m
+      - name: Check safetyValve content is correct
+        run: |
+          NPFP=$(kubectl exec pod/nifi-0 -c server -- ps auxww | \
+            awk 'BEGIN { RS = " " } /^-Dnifi.properties.file.path/ { split($0,a,"=",seps); printf("%s",a[2]) }')
+          kubectl exec pod/nifi-0 -c server -- cat $NPFP
+          kubectl exec pod/nifi-0 -c server -- cat $NPFP | \
+            grep 'nifi.content.claim.max.appendable.size=1 B'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,9 +36,19 @@ jobs:
         run: helm install nifi .
       - name: Check deployment status
         run: kubectl wait --for=condition=Ready pod/nifi-0 --timeout=20m
-      - name: Check web application is available
+      - name: Wait for NiFi web server to start
         run: |
-          sudo apt install socat 
-          kubectl port-forward service/nifi 8443:8443 &
-          sleep 2
-          curl https://127.0.0.1:8443
+          for n in [ 0 1 2 3 4 5 6 7 8 9 ]
+          do
+            if kubectl logs pod/nifi-0 -c app-log | grep 'JettyServer NiFi has started'
+            then
+              exit 0
+            fi
+            sleep 30
+          done
+          echo NiFi did not start for 300 seconds!
+          exit 1
+      - name: Check that web application responds with expected content
+        run: |
+          kubectl exec pod/nifi-0 -c server -- curl -sk https://localhost:8443 | \
+            grep 'You may have mistyped'


### PR DESCRIPTION
#### What this PR does / why we need it:

The master branch push and pull_request workflows will now actually watch the logs to confirm the NiFi web application has started, and that it returns the expected content.

#### Special notes for your reviewer:

@banzo @zakaria2905 please merge this soon; tomorrow I'm going to work on another pull request to address issue #208 and hope to include tests specific to confirming those fixes.  This PR does NOT resolve that issue, but it would be nice to have these changes in the master branch so I can build the next pull requests' additional tests on top of it.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- **NOT APPLICABLE** Chart Version bumped
- **NOT APPLICABLE** Variables are documented in the README.md
