### PR TITLE
Feature/add startup probe

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: nifi
-version: 1.0.5
+version: 1.0.6
 appVersion: 1.14.0
 description: Apache NiFi is a software project from the Apache Software Foundation designed to automate the flow of data between software systems.
 keywords:

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ The following table lists the configurable parameters of the nifi chart and the 
 | `sts.AntiAffinity`                                                          | Affinity for pod assignment                                                                                        | `soft`                          |
 | `sts.pod.annotations`                                                       | Pod template annotations                                                                                           | `security.alpha.kubernetes.io/sysctls: net.ipv4.ip_local_port_range=10000 65000`                          |
 | `sts.hostAliases    `                                                       | Add entries to Pod /etc/hosts                                                                                      | `[]`                            |
+| `sts.startupProbe.enabled`                                                  | enable Startup Probe on Nifi server container                                                                      | `false`                            |
+| `sts.startupProbe.failureThreshold`                                         | sets Startup Probe failureThreshold field value                                                                    | `60`                            |
+| `sts.startupProbe.periodSeconds`                                            | sets Startup Probe periodSeconds field value                                                                       | `10`                            |
 | **secrets**
 | `secrets`                                                                   | Pass any secrets to the nifi pods. The secret can also be mounted to a specific path if required.                  | `nil`                           |
 | **configmaps**

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -295,7 +295,9 @@ spec:
 {{- end }}
 {{- if .Values.properties.isNode }}
         readinessProbe:
+{{- if not .Values.sts.startupProbe.enabled  }}
           initialDelaySeconds: 60
+{{- end }}
           periodSeconds: 20
           tcpSocket:
             port: {{ .Values.properties.httpsPort }}
@@ -321,8 +323,17 @@ spec:
 #                 exit 1
 #               fi
 {{- end }}
+{{- if .Values.sts.startupProbe.enabled }}
+        startupProbe:
+          failureThreshold: {{ .Values.sts.startupProbe.failureThreshold }}
+          periodSeconds: {{ .Values.sts.startupProbe.periodSeconds }}
+          tcpSocket:
+            port: {{ .Values.properties.httpsPort }}
+{{- end }}
         livenessProbe:
+{{- if not .Values.sts.startupProbe.enabled }}
           initialDelaySeconds: 90
+{{- end }}
           periodSeconds: 60
           tcpSocket:
             port: {{ .Values.properties.httpsPort }}

--- a/values.yaml
+++ b/values.yaml
@@ -49,6 +49,11 @@ sts:
 #        - example.com
 #        - example
 
+  startupProbe:
+    enabled: false
+    failureThreshold: 60
+    periodSeconds: 10
+
 ## Useful if using any custom secrets
 ## Pass in some secrets to use (if required)
 # secrets:


### PR DESCRIPTION
<!--
Thank you for contributing to this repository. Before you submit this PR we'd like to
make sure you are aware of our technical requirements and best practices:

* https://github.com/helm/charts/blob/master/CONTRIBUTING.md#technical-requirements
* https://github.com/helm/helm/tree/master/docs/chart_best_practices

For a quick overview across what we will look at reviewing your PR, please read
the review guidelines form the Helm repository:

* https://github.com/helm/charts/blob/master/REVIEW_GUIDELINES.md

Following our best practices right from the start will accelerate the review process and
help get your PR merged quicker.

When updates to your PR are requested, please add new commits and do not squash the
history. This will make it easier to identify new changes. The PR will be squashed
anyways when it is merged. Thanks.

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them. Once pushed, a CircleCI
will run across your changes and do some initial checks and linting. These checks run
very quickly. Please check the results. We would like these checks to pass before we
even continue reviewing your changes.
-->

#### What this PR does / why we need it:

This PR incorporates a configurable Startup Probe for the Nifi server container.  This allows administrators to specify startup probe settings appropriate to the capabilities of a particular environment.

The setting is disabled by default to ensure backward compatibility with earlier versions of Kubernetes.

#### Which issue this PR fixes
*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*
  - fixes #

#### Special notes for your reviewer:

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md
