### PR TITLE
Fix LDAP bind dn forced as initial admin user

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: v2
 name: nifi
-version: 1.1.2
+version: 1.1.3
 appVersion: 1.16.3
 description: Apache NiFi is a software project from the Apache Software Foundation designed to automate the flow of data between software systems.
 keywords:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The following items can be set via `--set` flag during installation or configure
 
 #### Configure authentication
 
-- By default, the authentication is a `Single-User` authentication. You can optionally enable `ldap` or `oidc` to provide an external authentication. See the [configuration section](README.md#configuration) or [doc](doc/) folder for more details. 
+- By default, the authentication is a `Single-User` authentication. You can optionally enable `ldap` or `oidc` to provide an external authentication. See the [configuration section](README.md#configuration) or [doc](doc/) folder for more details.
 
 #### Use custom processors
 
@@ -60,10 +60,10 @@ To add [custom processors](https://cwiki.apache.org/confluence/display/NIFI/Mave
 
 #### Configure prometheus monitoring
 
-- You first need monitoring to be enabled which can be accomplished by enabling the appropriate metrics flag (`metrics.prometheus.enabled` to true). 
+- You first need monitoring to be enabled which can be accomplished by enabling the appropriate metrics flag (`metrics.prometheus.enabled` to true).
 To enable the creation of prometheus metrics within Nifi we need to create a *Reporting Task*. Login to the Nifi UI and go to the Hamburger menu on the top right corner, click *Controller Settings* --> *Reporting Tasks* After that use the + icon to add a task. Click on the *Reporting* in the wordcloud on the left and select *PrometheusReportingTask* --> change *Send JVM metrics* to `true` and click on the play button to enable this task.
 
-If you plan to use Grafana for the visualization of the metrics data [the following dashboard](https://grafana.com/grafana/dashboards/12314) is compatible with the exposed metrics. 
+If you plan to use Grafana for the visualization of the metrics data [the following dashboard](https://grafana.com/grafana/dashboards/12314) is compatible with the exposed metrics.
 
 ### Install the chart
 
@@ -135,12 +135,13 @@ The following table lists the configurable parameters of the nifi chart and the 
 | `properties.webProxyHost`                               | Proxy to access to Nifi through the cluster ip address    | `Port:30236`
 | **[Authentication](/doc/USERMANAGEMENT.md)**                                                |
 | **Single-user authentication**                                                | Automatically disabled if Client Certificate, OIDC, or LDAP enabled
+| `auth.     admin`                                                           | Default admin identity. It will overwrite the LDAP Bind DN for this purpose, when both is filled                   | ` CN=admin, OU=NIFI`            |
 | `auth.singleUser.username`                                                                | Single user identity                                                                                             | `username`            |
 | `auth.singleUser.password`                                                         | Single user password                                                                                          | `changemechangeme`                         |
 | **Client Certificate authentication**       |
 | `auth.clientAuth.enabled`       |     Enable User auth via Client Certificates       |     `false`
 | **Ldap authentication**                                                |
-| `auth.admin`                                                                | Default admin identity                                                                                             | ` CN=admin, OU=NIFI`            |
+| `auth.ldap.admin`                                                           | Default admin identity and LDAP Bind DN                                                                            | ` CN=admin, OU=NIFI`            |
 | `auth.ldap.enabled`                                                         | Enable User auth via ldap                                                                                          | `false`                         |
 | `auth.ldap.host`                                                            | ldap hostname                                                                                                      | `ldap://<hostname>:<port>`      |
 | `auth.ldap.searchBase`                                                      | ldap searchBase                                                                                                    | `CN=Users,DC=example,DC=com`    |

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ The following table lists the configurable parameters of the nifi chart and the 
 | **Client Certificate authentication**       |
 | `auth.clientAuth.enabled`       |     Enable User auth via Client Certificates       |     `false`
 | **Ldap authentication**                                                |
-| `auth.ldap.admin`                                                           | Default admin identity and LDAP Bind DN                                                                            | ` CN=admin, OU=NIFI`            |
+| `auth.ldap.admin`                                                           | Default admin identity and LDAP Bind DN                                                                            |                                 |
 | `auth.ldap.enabled`                                                         | Enable User auth via ldap                                                                                          | `false`                         |
 | `auth.ldap.host`                                                            | ldap hostname                                                                                                      | `ldap://<hostname>:<port>`      |
 | `auth.ldap.searchBase`                                                      | ldap searchBase                                                                                                    | `CN=Users,DC=example,DC=com`    |

--- a/configs/authorizers.xml
+++ b/configs/authorizers.xml
@@ -50,7 +50,7 @@
         {{- range $i := until $replicas }}
         <property name="Initial User Identity {{ $i }}">CN={{ $fullname }}-{{ $i }}.{{ $fullname }}-headless.{{ $namespace }}.svc.cluster.local, OU=NIFI</property>
         {{- end }}
-        {{- if .Values.auth.ldap.enabled}}
+        {{- if and .Values.auth.ldap.enabled (not .Values.auth.admin) }}
         <property name="Initial User Identity admin">{{.Values.auth.ldap.admin}}</property>
         {{- else }}
         <property name="Initial User Identity admin">{{ .Values.auth.admin }}</property>
@@ -222,7 +222,7 @@
         <class>org.apache.nifi.authorization.FileAccessPolicyProvider</class>
         <property name="User Group Provider">file-user-group-provider</property>
         <property name="Authorizations File">./auth-conf/authorizations.xml</property>
-        {{- if .Values.auth.ldap.enabled}}
+        {{- if and .Values.auth.ldap.enabled (not .Values.auth.admin) }}
         <property name="Initial Admin Identity">{{.Values.auth.ldap.admin}}</property>
         {{- else }}
         <property name="Initial Admin Identity">{{ .Values.auth.admin }}</property>

--- a/doc/USERMANAGEMENT.md
+++ b/doc/USERMANAGEMENT.md
@@ -1,19 +1,18 @@
-User Authentication
-=============
+# User Authentication
 
-This helm chart provides four types of authentication: Single User, Client Certificate, LDAP, and OIDC. These four authentication types can be managed essentialy from the `values.yaml` file. 
+This helm chart provides four types of authentication: Single User, Client Certificate, LDAP, and OIDC. These four authentication types can be managed essentialy from the `values.yaml` file.
 
+The parameter `admin` will set the initial admin username. If used in conjunction with an enabled LDAP configuration, this value will get used instead of the LDAP Bind DN for the admin username.
 
 ## 1. Single User
 
 The Single User authentication is the default authentication in this helm chart. To login like a single user, the values below must be set in `values.yaml` file:
 
-````
+```
 singleUser:
     username: username
     password: changemechangeme
-````
-
+```
 
 ## 2. Client Certificate
 
@@ -21,56 +20,56 @@ Client Certificate authentication assumes a central Certificate Authority (CA) w
 
 Add keystore files to a Kubernetes secret:
 
-````
+```
 kubectl create secret generic mysecrets \
 --from-file=keystore.jks=/path/to/keystore.jks \
 --from-file=truststore.jks=/path/to/truststore.jks
-````
+```
 
-Make the Kubernetes secret available to the Nifi server.  Update `values.yaml`:
+Make the Kubernetes secret available to the Nifi server. Update `values.yaml`:
 
-````
+```
 secrets:
 - name: mysecrets
   keys:
     - keystore.jks
     - truststore.jks
   mountPath: /opt/nifi/nifi-current/config-data/certs/
-````
+```
 
 Enable the Nifi server to prompt for client certificates:
 
-````
+```
 properties:
    needClientAuth: true
-````
+```
 
 Indicate Client Authentication mode configurations should be applied and set SSL values:
 
-````
+```
 auth:
    SSL:
      keystorePasswd: <passwd>
      truststorePasswd: <passwd>
-   clientAuth: 
+   clientAuth:
      enabled: true
-````
+```
 
 For cluster deployments, the example below illustrates how to create a 3 replica cluster with unique keystores.
 
 Create the secret:
 
-````
+```
 kubectl create secret generic mysecrets \
 --from-file=<nifi-0 fqdn>.jks=/path/to/<nifi-0 fqdn>.jks \
 --from-file=<nifi-1 fqdn>.jks=/path/to/<nifi-1 fqdn>.jks \
 --from-file=<nifi-2 fqdn>.jks=/path/to/<nifi-2 fqdn>.jks \
 --from-file=truststore.jks=/path/to/truststore.jks
-````
+```
 
 Make the secret available to the replicas:
 
-````
+```
 secrets:
 - name: mysecrets
   keys:
@@ -79,24 +78,23 @@ secrets:
     - <nifi-2 fqdn>.jks
     - truststore.jks
   mountPath: /opt/nifi/nifi-current/config-data/certs/
-````
+```
 
-Add a safetyValve entry to align the container with the associated keystore: 
+Add a safetyValve entry to align the container with the associated keystore:
 
-````
+```
 properties:
   safetyValve:
     nifi.security.keystore: ${NIFI_HOME}/config-data/certs/${FQDN}.jks
-````
-
+```
 
 ## 3. OIDC
 
-OpenID Connect (OIDC) is an open authentication protocol that profiles and extends OAuth 2.0 to add an identity layer. It can be used by an external identity provider to make authentication. 
+OpenID Connect (OIDC) is an open authentication protocol that profiles and extends OAuth 2.0 to add an identity layer. It can be used by an external identity provider to make authentication.
 
 To enable OIDC user authentication, the values below must be set in `values.yaml` file:
 
-````
+```
 oidc:
     enabled: true
     discoveryUrl: http://<oidc_provider_address>:<oidc_provider_port>/auth/realms/<client_realm>/.well-known/openid-configuration
@@ -104,10 +102,9 @@ oidc:
     clientSecret: <client_secret_in_oidc_provider>
     claimIdentifyingUser: email
     admin: nifi@example.com
-````
+```
 
 There are a lot of ID providers that can be used to perform an OIDC authentication. In our case, we have tested that with Keycloak. You will find an example of Keycloak config on this [page](doc/KEYCLOAK.md).
-
 
 ## 4. LDAP
 
@@ -115,11 +112,11 @@ Like OIDC, LDAP (Lightweight Directory Access Protocol) provide an external auth
 
 To enable authentication through LDAP, set the values below in `values.yaml` file:
 
-````
+```
 ldap:
     enabled: true
     host: ldap://<hostname>:<port>
     searchBase: CN=Users,DC=example,DC=com
     admin: cn=admin,dc=example,dc=be
     pass: changeMe
-````
+```

--- a/values.yaml
+++ b/values.yaml
@@ -38,7 +38,7 @@ sts:
   pod:
     annotations:
       security.alpha.kubernetes.io/sysctls: net.ipv4.ip_local_port_range=10000 65000
-      #prometheus.io/scrape: "true"      
+      #prometheus.io/scrape: "true"
   serviceAccount:
     create: false
     #name: nifi
@@ -91,7 +91,7 @@ properties:
   # use externalSecure for when inbound SSL is provided by nginx-ingress or other external mechanism
   externalSecure: false
   isNode: false
-  httpsPort: 8443 
+  httpsPort: 8443
   webProxyHost: # <clusterIP>:<NodePort> (If Nifi service is NodePort or LoadBalancer)
   clusterPort: 6007
   provenanceStorage: "8 GB"
@@ -113,12 +113,13 @@ properties:
 
 # Nifi User Authentication
 auth:
+  # If set while LDAP is enabled, this value will be used for the initial admin and not the ldap bind dn / admin
   admin: CN=admin, OU=NIFI
   SSL:
     keystorePasswd: changeMe
     truststorePasswd: changeMe
-  
-  # Automaticaly disabled if OIDC or LDAP enabled 
+
+  # Automaticaly disabled if OIDC or LDAP enabled
   singleUser:
     username: username
     password: changemechangeme # Must to have at least 12 characters
@@ -379,11 +380,11 @@ certManager:
       cpu: 100m
       memory: 128Mi
   # cert-manager takes care of rotating the node certificates, so default
-  # their lifetime to 90 days.  But when the CA expires you may need to 
-  # 'helm delete' the cluster, delete all the node certificates and secrets, 
+  # their lifetime to 90 days.  But when the CA expires you may need to
+  # 'helm delete' the cluster, delete all the node certificates and secrets,
   # and then 'helm install' the NiFi cluster again.  If a site-to-site trusted
-  # CA or a NiFi Registry CA certificate expires, you'll need to restart all 
-  # pods to pick up the new version of the CA certificate.  So default the CA 
+  # CA or a NiFi Registry CA certificate expires, you'll need to restart all
+  # pods to pick up the new version of the CA certificate.  So default the CA
   # lifetime to 10 years to avoid that happening very often.
   # c.f. https://github.com/cert-manager/cert-manager/issues/2478#issuecomment-1095545529
   certDuration: 2160h


### PR DESCRIPTION
#### What this PR does / why we need it:

Currently the LDAP bind dn gets used as the initial admin identity, when LDAP authentication is enabled. See #278 

#### Which issue this PR fixes
  - fixes #278 

#### Special notes for your reviewer:

#### Checklist
- [x] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [x] Chart Version bumped
- [x] Variables are documented in the README.md