### PR TITLE
Allow addition of containerPort(s) to nifi via Helm Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ The following table lists the configurable parameters of the nifi chart and the 
 | `service.loadBalancerSourceRanges`                                          | Address that are allowed when svc is `LoadBalancer`                                                                | `[]`                            |
 | `service.processors.enabled`                                                | Enables additional port/ports to nifi service for internal processors                                              | `false`                         |
 | `service.processors.ports`                                                  | Specify "name/port/targetPort/nodePort" for processors  sockets                                                    | `[]`                            |
+| **ContainerPorts**       |                                                  |
+| `containerPorts`                                                            | Additional containerPorts for the nifi-container. Example is given in values.yaml  | `[]` 
 | **Ingress**                                                                 |
 | `ingress.enabled`                                                           | Enables Ingress                                                                                                    | `false`                         |
 | `ingress.className`      | Ingress controller Class                                                                                   | `nginx`                                  |

--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -385,6 +385,9 @@ spec:
         - containerPort: {{ .Values.properties.clusterPort }}
           name: cluster
           protocol: TCP
+{{- if .Values.containerPorts  }}
+{{ toYaml .Values.containerPorts | indent 8 }}
+{{- end }}
         env:
         - name: NIFI_ZOOKEEPER_CONNECT_STRING
           value: {{ template "zookeeper.url" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -208,6 +208,11 @@ service:
         port: 7002
         targetPort: 7002
         #nodePort: 30702
+## Configure containerPorts section with following attributes: name, containerport and protocol. 
+containerPorts: []
+# - name: example
+#   containerPort: 1111
+#   protocol: TCP 
 
 ## Configure Ingress based on the documentation here: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ##


### PR DESCRIPTION
#### What this PR does / why we need it:
This PR is created because current chart functionality doesn't allow for modification or additions of Container Ports for the nifi pod. With this addition, we can now configure extra ports that can be listened on in order to utilize other functionality of Nifi in Kubernetes. For our use case, we need to actively manage additional ports because of some processors in NiFi where we can choose to listen on certain ports. Issue was that ports cannot be changed or added in Chart values. 

#### Which issue this PR fixes
N/A

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [X] Variables are documented in the README.md
