### PR TITLE
Make compatible with apache/nifi >= 1.19.0 (#313)

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -659,6 +659,7 @@ spec:
                     -noprompt \
                     -trustcacerts \
                     -alias $ALIAS \
+                    -storetype JKS \
                     -file $ca \
                     -keystore "${NIFI_HOME}/tls/truststore-new.jks" \
                     -storepass "{{ .Values.certManager.truststorePasswd }}"
@@ -685,6 +686,7 @@ spec:
                       -destkeystore "${NIFI_HOME}/tls/keystore-new.jks" \
                       -srckeystore "/tmp/tls.p12" \
                       -srcstoretype PKCS12 \
+                      -deststoretype JKS \
                       -srcstorepass "{{ .Values.certManager.keystorePasswd }}" \
                       -deststorepass "{{ .Values.certManager.keystorePasswd }}"
               mv  "${NIFI_HOME}/tls/keystore-new.jks" "${NIFI_HOME}/tls/keystore.jks"


### PR DESCRIPTION
#### What this PR does / why we need it:

This pull request allows `apache/nifi` versions `>=0.19.0` to be released with this helm chart.

As described in issue #313, this only required the keystore type to be explicitly set to `JKS` when calling `keytool` to be compatible with Java 11.

This change is backward compatible with Java 8. 

#### Which issue this PR fixes

  - fixes #313

#### Checklist
- [X] [DCO](https://github.com/helm/charts/blob/master/CONTRIBUTING.md#sign-your-work) signed
- [ ] Chart Version bumped
