### PR TITLE
Deprecated script to install Node for OIDC testing

### DIFF
--- a/.github/workflows/test-oidc.yml
+++ b/.github/workflows/test-oidc.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          curl -sL https://deb.nodesource.com/setup_16.x -o nodesource_setup.sh
+          curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh
           sudo bash nodesource_setup.sh
           sudo apt-get install -y jq yarn
           yarn add puppeteer-core --cwd $HOME


### PR DESCRIPTION
Try to fix #328 

The script used to install node.js is deprecated.
test-oidc.yml line 24
curl -sL https://deb.nodesource.com/setup_16.x -o nodesource_setup.sh